### PR TITLE
feat: support ClipToBounds for Border

### DIFF
--- a/EleCho.WpfSuite.FluentDesign/EleCho.WpfSuite.FluentDesign.csproj
+++ b/EleCho.WpfSuite.FluentDesign/EleCho.WpfSuite.FluentDesign.csproj
@@ -25,10 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Controls\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Page Update="Styles\PasswordBoxResources.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/EleCho.WpfSuite/Controls/Border.cs
+++ b/EleCho.WpfSuite/Controls/Border.cs
@@ -53,7 +53,6 @@ namespace EleCho.WpfSuite
 
                 contentGeometry.Freeze();
                 return contentGeometry;
-
             }
             else
             {
@@ -62,10 +61,36 @@ namespace EleCho.WpfSuite
         }
 
         /// <inheritdoc/>
-        protected override void OnRender(DrawingContext dc)
+        protected override Size ArrangeOverride(Size finalSize)
         {
             SetValue(ContentClipPropertyKey, CalculateContentClip());
-            base.OnRender(dc);
+
+            return base.ArrangeOverride(finalSize);
+        }
+
+        /// <inheritdoc/>
+        protected override Geometry GetLayoutClip(Size layoutSlotSize)
+        {
+            var borderThickness = BorderThickness;
+            var cornerRadius = CornerRadius;
+            var renderSize = RenderSize;
+
+            if (renderSize.Width > 0 && renderSize.Height > 0)
+            {
+                var rect = new Rect(0, 0, renderSize.Width, renderSize.Height);
+                var radii = new Radii(cornerRadius, borderThickness, true);
+
+                var layoutGeometry = new StreamGeometry();
+                using StreamGeometryContext ctx = layoutGeometry.Open();
+                GenerateGeometry(ctx, rect, radii);
+
+                layoutGeometry.Freeze();
+                return layoutGeometry;
+            }
+            else
+            {
+                return base.GetLayoutClip(layoutSlotSize);
+            }
         }
 
         /// <summary>
@@ -200,10 +225,10 @@ namespace EleCho.WpfSuite
         {
             internal Radii(CornerRadius radii, Thickness borders, bool outer)
             {
-                double left     = 0.5 * borders.Left;
-                double top      = 0.5 * borders.Top;
-                double right    = 0.5 * borders.Right;
-                double bottom   = 0.5 * borders.Bottom;
+                double left = 0.5 * borders.Left;
+                double top = 0.5 * borders.Top;
+                double right = 0.5 * borders.Right;
+                double bottom = 0.5 * borders.Bottom;
 
                 if (outer)
                 {
@@ -265,20 +290,6 @@ namespace EleCho.WpfSuite
             internal double BottomRight;
             internal double BottomLeft;
             internal double LeftBottom;
-        }
-
-        /// <inheritdoc/>
-        protected override Geometry GetLayoutClip(Size layoutSlotSize)
-        {
-            if (ClipToBounds)
-            {
-                var radius = CornerRadius.TopLeft;
-                var rect = new RectangleGeometry(new Rect(layoutSlotSize), radius, radius);
-                rect.Freeze();
-                return rect;
-            }
-
-            return base.GetLayoutClip(layoutSlotSize);
         }
     }
 }

--- a/EleCho.WpfSuite/Controls/Border.cs
+++ b/EleCho.WpfSuite/Controls/Border.cs
@@ -266,5 +266,19 @@ namespace EleCho.WpfSuite
             internal double BottomLeft;
             internal double LeftBottom;
         }
+
+        /// <inheritdoc/>
+        protected override Geometry GetLayoutClip(Size layoutSlotSize)
+        {
+            if (ClipToBounds)
+            {
+                var radius = CornerRadius.TopLeft;
+                var rect = new RectangleGeometry(new Rect(layoutSlotSize), radius, radius);
+                rect.Freeze();
+                return rect;
+            }
+
+            return base.GetLayoutClip(layoutSlotSize);
+        }
     }
 }

--- a/WpfTest/Tests/TempPage.xaml
+++ b/WpfTest/Tests/TempPage.xaml
@@ -251,7 +251,14 @@
 
             <RepeatButton Content="QWQ"/>
 
-
+            <ws:Border ClipToBounds="True"
+                       CornerRadius="5 10 15 20"
+                       BorderThickness="3"
+                       BorderBrush="Red"
+                       MaxWidth="200"
+                       Name="testClip">
+                <Image Source="/Assets/TestImage2.jpg"/>
+            </ws:Border>
 
         </ws:StackPanel>
     </ws:ScrollViewer>


### PR DESCRIPTION
In WinUI, `ClipToBounds` works as expected, but in WPF...
So override `GetLayoutClip` to approach WinUI.

Usage:
```xaml
  <xxx:Border
      ClipToBounds="True"
      CornerRadius="60">
      <Image Source="https://avatars.githubusercontent.com/u/24737061" />
  </local:Border>
```

Effect:
![image](https://github.com/user-attachments/assets/4601d1f9-04db-4669-91cf-7ce233631662)
