### PR TITLE
fix:WpfTest-Transition为RotateFade时切换到Welcome崩溃的情况

### DIFF
--- a/WpfTest/WelcomePage.xaml
+++ b/WpfTest/WelcomePage.xaml
@@ -61,6 +61,7 @@
 
             <WindowsFormsHost Background="White" 
                               HorizontalAlignment="Stretch"
+                              LayoutError="OnLayoutError"
                               Height="500">
                 <winforms:Panel>
                     <winforms:Panel.Controls>

--- a/WpfTest/WelcomePage.xaml.cs
+++ b/WpfTest/WelcomePage.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
+using System.Windows.Forms.Integration;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -50,6 +51,11 @@ namespace WpfTest
             InitializeComponent();
 
             DataContext = this;
+        }
+
+        private void OnLayoutError(object sender, LayoutExceptionEventArgs e)
+        {
+            e.ThrowException = false;
         }
 
         [RelayCommand]


### PR DESCRIPTION
修复了一个示例程序WpfTest中Transition为RotateFade时切换到Welcome页面会崩溃的小bug，已编译试验。