### PR TITLE
MouseOver issue with Custom Caption Buttons on Second Monitor

### DIFF
--- a/EleCho.WpfSuite.Controls/EleCho.WpfSuite.Controls.csproj
+++ b/EleCho.WpfSuite.Controls/EleCho.WpfSuite.Controls.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Package.props" />
 
   <PropertyGroup>
-    <Version>0.10.0.1</Version>
+    <Version>0.10.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EleCho.WpfSuite.Helpers/Helpers/WindowOption.cs
+++ b/EleCho.WpfSuite.Helpers/Helpers/WindowOption.cs
@@ -464,25 +464,229 @@ namespace EleCho.WpfSuite.Helpers
             switch ((nint)msg)
             {
                 case NativeDefinition.WM_NCHITTEST:
-                {
-                    var x = (int)((ulong)lParam & 0x0000FFFF);
-                    var y = (int)((ulong)lParam & 0xFFFF0000) >> 16;
-                    var result = default(IntPtr);
-
-                    if (s_maximumButtons is not null &&
-                        s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
                     {
-                        var relativePoint = maximumButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(maximumButtonVisual, relativePoint);
+                        var x = (short)(lParam.ToInt32() & 0x0000FFFF);
+                        var y = (short)((lParam.ToInt32() >> 16) & 0x0000FFFF);
+                        var result = default(IntPtr);
 
-                        if (hitResult is not null)
+                        if (s_maximumButtons is not null &&
+                            s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
                         {
-                            maximumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
+                            var relativePoint = maximumButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(maximumButtonVisual, relativePoint);
 
-                            handled = true;
-                            result = NativeDefinition.HTMAXBUTTON;
+                            if (hitResult is not null)
+                            {
+                                maximumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
+
+                                handled = true;
+                                result = NativeDefinition.HTMAXBUTTON;
+                            }
+                            else
+                            {
+                                maximumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
+
+                                if (maximumButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, false);
+                                }
+                            }
                         }
-                        else
+
+                        if (s_minimumButtons is not null &&
+                            s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
+                        {
+                            var relativePoint = minimumButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(minimumButtonVisual, relativePoint);
+
+                            if (hitResult is not null)
+                            {
+                                minimumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
+
+                                handled = true;
+                                result = NativeDefinition.HTMINBUTTON;
+                            }
+                            else
+                            {
+                                minimumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
+
+                                if (minimumButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, false);
+                                }
+                            }
+                        }
+
+                        if (s_closeButtons is not null &&
+                            s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
+                        {
+                            var relativePoint = closeButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(closeButtonVisual, relativePoint);
+
+                            if (hitResult is not null)
+                            {
+                                closeButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
+
+                                handled = true;
+                                result = NativeDefinition.HTCLOSE;
+                            }
+                            else
+                            {
+                                closeButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
+
+                                if (closeButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, false);
+                                }
+                            }
+                        }
+
+                        return result;
+                    }
+
+                case NativeDefinition.WM_NCLBUTTONDOWN:
+                    {
+                        var x = (short)(lParam.ToInt32() & 0x0000FFFF);
+                        var y = (short)((lParam.ToInt32() >> 16) & 0x0000FFFF);
+
+                        if (s_maximumButtons is not null &&
+                            s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
+                        {
+                            var relativePoint = maximumButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(maximumButtonVisual, relativePoint);
+
+                            if (hitResult is not null)
+                            {
+                                if (maximumButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, true);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        if (s_minimumButtons is not null &&
+                            s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
+                        {
+                            var relativePoint = minimumButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(minimumButtonVisual, relativePoint);
+
+                            if (hitResult is not null)
+                            {
+                                if (minimumButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, true);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        if (s_closeButtons is not null &&
+                            s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
+                        {
+                            var relativePoint = closeButtonVisual.PointFromScreen(new Point(x, y));
+                            var hitResult = VisualTreeHelper.HitTest(closeButtonVisual, relativePoint);
+
+                            if (hitResult is not null)
+                            {
+                                if (closeButtonVisual is ButtonBase button)
+                                {
+                                    button.SetValue(s_buttonIsPressedPropertyKey, true);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        break;
+                    }
+
+                case NativeDefinition.WM_NCLBUTTONUP:
+                    {
+                        var x = (short)(lParam.ToInt32() & 0x0000FFFF);
+                        var y = (short)((lParam.ToInt32() >> 16) & 0x0000FFFF);
+
+                        if (s_maximumButtons is not null &&
+                            s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
+                        {
+                            if (maximumButtonVisual is ButtonBase button)
+                            {
+                                bool shouldClick = false;
+                                if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
+                                {
+                                    shouldClick = true;
+                                }
+
+                                button.SetValue(s_buttonIsPressedPropertyKey, false);
+
+                                if (shouldClick)
+                                {
+                                    button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
+                                    button.Command?.Execute(button.CommandParameter);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        if (s_minimumButtons is not null &&
+                            s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
+                        {
+                            if (minimumButtonVisual is ButtonBase button)
+                            {
+                                bool shouldClick = false;
+                                if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
+                                {
+                                    shouldClick = true;
+                                }
+
+                                button.SetValue(s_buttonIsPressedPropertyKey, false);
+
+                                if (shouldClick)
+                                {
+                                    button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
+                                    button.Command?.Execute(button.CommandParameter);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        if (s_closeButtons is not null &&
+                            s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
+                        {
+                            if (closeButtonVisual is ButtonBase button)
+                            {
+                                bool shouldClick = false;
+                                if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
+                                {
+                                    shouldClick = true;
+                                }
+
+                                button.SetValue(s_buttonIsPressedPropertyKey, false);
+
+                                if (shouldClick)
+                                {
+                                    button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
+                                    button.Command?.Execute(button.CommandParameter);
+                                }
+
+                                handled = true;
+                            }
+                        }
+
+                        break;
+                    }
+
+                case NativeDefinition.WM_NCMOUSELEAVE:
+                    {
+                        var x = (short)(lParam.ToInt32() & 0x0000FFFF);
+                        var y = (short)((lParam.ToInt32() >> 16) & 0x0000FFFF);
+
+                        if (s_maximumButtons is not null &&
+                            s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
                         {
                             maximumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
 
@@ -491,22 +695,9 @@ namespace EleCho.WpfSuite.Helpers
                                 button.SetValue(s_buttonIsPressedPropertyKey, false);
                             }
                         }
-                    }
 
-                    if (s_minimumButtons is not null &&
-                        s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
-                    {
-                        var relativePoint = minimumButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(minimumButtonVisual, relativePoint);
-
-                        if (hitResult is not null)
-                        {
-                            minimumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
-
-                            handled = true;
-                            result = NativeDefinition.HTMINBUTTON;
-                        }
-                        else
+                        if (s_minimumButtons is not null &&
+                            s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
                         {
                             minimumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
 
@@ -515,22 +706,9 @@ namespace EleCho.WpfSuite.Helpers
                                 button.SetValue(s_buttonIsPressedPropertyKey, false);
                             }
                         }
-                    }
 
-                    if (s_closeButtons is not null &&
-                        s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
-                    {
-                        var relativePoint = closeButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(closeButtonVisual, relativePoint);
-
-                        if (hitResult is not null)
-                        {
-                            closeButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, true);
-
-                            handled = true;
-                            result = NativeDefinition.HTCLOSE;
-                        }
-                        else
+                        if (s_closeButtons is not null &&
+                            s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
                         {
                             closeButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
 
@@ -539,187 +717,9 @@ namespace EleCho.WpfSuite.Helpers
                                 button.SetValue(s_buttonIsPressedPropertyKey, false);
                             }
                         }
+
+                        break;
                     }
-
-                    return result;
-                }
-
-                case NativeDefinition.WM_NCLBUTTONDOWN:
-                {
-                    var x = (int)((ulong)lParam & 0x0000FFFF);
-                    var y = (int)((ulong)lParam & 0xFFFF0000) >> 16;
-
-                    if (s_maximumButtons is not null &&
-                        s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
-                    {
-                        var relativePoint = maximumButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(maximumButtonVisual, relativePoint);
-
-                        if (hitResult is not null)
-                        {
-                            if (maximumButtonVisual is ButtonBase button)
-                            {
-                                button.SetValue(s_buttonIsPressedPropertyKey, true);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    if (s_minimumButtons is not null &&
-                        s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
-                    {
-                        var relativePoint = minimumButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(minimumButtonVisual, relativePoint);
-
-                        if (hitResult is not null)
-                        {
-                            if (minimumButtonVisual is ButtonBase button)
-                            {
-                                button.SetValue(s_buttonIsPressedPropertyKey, true);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    if (s_closeButtons is not null &&
-                        s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
-                    {
-                        var relativePoint = closeButtonVisual.PointFromScreen(new Point(x, y));
-                        var hitResult = VisualTreeHelper.HitTest(closeButtonVisual, relativePoint);
-
-                        if (hitResult is not null)
-                        {
-                            if (closeButtonVisual is ButtonBase button)
-                            {
-                                button.SetValue(s_buttonIsPressedPropertyKey, true);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    break;
-                }
-
-                case NativeDefinition.WM_NCLBUTTONUP:
-                {
-                    var x = (int)((ulong)lParam & 0x0000FFFF);
-                    var y = (int)((ulong)lParam & 0xFFFF0000) >> 16;
-
-                    if (s_maximumButtons is not null &&
-                        s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
-                    {
-                        if (maximumButtonVisual is ButtonBase button)
-                        {
-                            bool shouldClick = false;
-                            if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
-                            {
-                                shouldClick = true;
-                            }
-
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-
-                            if (shouldClick)
-                            {
-                                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
-                                button.Command?.Execute(button.CommandParameter);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    if (s_minimumButtons is not null &&
-                        s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
-                    {
-                        if (minimumButtonVisual is ButtonBase button)
-                        {
-                            bool shouldClick = false;
-                            if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
-                            {
-                                shouldClick = true;
-                            }
-
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-
-                            if (shouldClick)
-                            {
-                                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
-                                button.Command?.Execute(button.CommandParameter);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    if (s_closeButtons is not null &&
-                        s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
-                    {
-                        if (closeButtonVisual is ButtonBase button)
-                        {
-                            bool shouldClick = false;
-                            if ((bool)button.GetValue(s_buttonIsPressedPropertyKey.DependencyProperty))
-                            {
-                                shouldClick = true;
-                            }
-
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-
-                            if (shouldClick)
-                            {
-                                button.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent, button));
-                                button.Command?.Execute(button.CommandParameter);
-                            }
-
-                            handled = true;
-                        }
-                    }
-
-                    break;
-                }
-
-                case NativeDefinition.WM_NCMOUSELEAVE:
-                {
-                    var x = (int)((ulong)lParam & 0x0000FFFF);
-                    var y = (int)((ulong)lParam & 0xFFFF0000) >> 16;
-
-                    if (s_maximumButtons is not null &&
-                        s_maximumButtons.TryGetValue(hwnd, out var maximumButtonVisual))
-                    {
-                        maximumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
-
-                        if (maximumButtonVisual is ButtonBase button)
-                        {
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-                        }
-                    }
-
-                    if (s_minimumButtons is not null &&
-                        s_minimumButtons.TryGetValue(hwnd, out var minimumButtonVisual))
-                    {
-                        minimumButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
-
-                        if (minimumButtonVisual is ButtonBase button)
-                        {
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-                        }
-                    }
-
-                    if (s_closeButtons is not null &&
-                        s_closeButtons.TryGetValue(hwnd, out var closeButtonVisual))
-                    {
-                        closeButtonVisual.SetValue(s_uiElementIsMouseOverPropertyKey, false);
-
-                        if (closeButtonVisual is ButtonBase button)
-                        {
-                            button.SetValue(s_buttonIsPressedPropertyKey, false);
-                        }
-                    }
-
-                    break;
-                }
             }
 
             return IntPtr.Zero;

--- a/EleCho.WpfSuite/EleCho.WpfSuite.csproj
+++ b/EleCho.WpfSuite/EleCho.WpfSuite.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Package.props" />
 
   <PropertyGroup>
-    <Version>0.10.0.1</Version>
+    <Version>0.10.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Issue encountered
When using the `EleCho.WpfSuite` package to create custom caption buttons in a WPF application, everything works fine on the primary monitor.
However, if the user moves the window to a secondary monitor positioned to the left of the primary screen, the behavior of the custom buttons is affected:

- Mouse hover effects (Minimize, Maximize, Close) stop working.
- The Maximize button no longer triggers the Windows 11 Snap Layout popup.
- The buttons do not respond to clicks anymore.

This issue only occurs when the secondary monitor has negative coordinates (e.g., X < 0).

### Why does this bug occur?
The issue comes from how `LPARAM `is processed in the WindowHook method of the Windows hook.

- `LPARAM `is a pointer stored in an `IntPtr`, but in this case, it contains a 32-bit value.
- Initially, `LPARAM `was cast to `ulong `(64-bit unsigned) before extracting the X and Y coordinates using 32-bit masks.
- These coordinates were then stored in `int `(32-bit signed) variables.

⚠ **However, when the X or Y coordinates are negative, this process leads to incorrect conversion:**

- The 16th bit (most significant bit) should indicate the sign.
- But by casting directly to int (32-bit signed), the 32nd bit is used for the sign instead of the 16th bit.
- As a result, a negative coordinate is misinterpreted as a large positive value (~65536 instead of -1).

This prevents the Windows hook from correctly detecting the mouse position, breaking the button behaviors.

### Solution applied
To fix this issue, we need to ensure that the extracted 16-bit value is stored in a `short `(16-bit signed), so that the 16th bit is correctly used for the sign.

`🔧 Code fix applied:`

``` csharp
// Old code (bugged)
var x = (int)((ulong)lParam & 0x0000FFFF);
var y = (int)((ulong)lParam & 0xFFFF0000) >> 16;

// New code (fixed)
var x = (short)(lParam.ToInt32() & 0x0000FFFF);
var y = (short)((lParam.ToInt32() >> 16) & 0x0000FFFF);
```

**✅ Why does this fix work?**

- `ToInt32()` directly extracts the 32-bit value from `LPARAM`, avoiding incorrect conversion to `ulong`.
- The `0x0000FFFF` mask is applied as before to extract the coordinates.
- The coordinates are stored in a `short `(16-bit signed), ensuring that the 16th bit (most significant bit) is correctly used for the sign.
- Thus, negative values are properly interpreted.

### Results
✔️ Negative coordinates are correctly recognized.
✔️ Caption buttons now respond correctly to hover and clicks, even on a secondary monitor.
✔️ The Snap Layout popup correctly appears on the Maximize button.
✔️ The general behavior of the Windows hook remains unchanged for screens without negative coordinates.

### Additional Information

- I do not have access to a Windows 10 machine for testing, but there is a high chance that this bug also occurs on Windows 10.
- Now that you know how to configure the screens to reproduce the bug (secondary monitor positioned to the left), you should be able to test it more easily.
- Let me know if any additional tests are needed!